### PR TITLE
Make sure that caret is in the beginning when an empty value gets focused

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -38,6 +38,9 @@
         utils.moveCaret(element, 0);
       } else if (isActiveAndHasPlaceholderSet(element)) {
         polyfill.hidePlaceholder(element);
+        if (element.value === "") {
+          utils.moveCaret(element, 0);
+        }
       }
     };
   }

--- a/test/unit/existing-value.spec.js
+++ b/test/unit/existing-value.spec.js
@@ -28,6 +28,19 @@ describe("existing value", function() {
       expect(element).not.toHaveClass("placeholder");
     });
 
+    describe("and when element is focused", function() {
+
+      beforeEach(function() {
+        spyOn(placekeeper.utils, "moveCaret");
+        helpers.focus(element);
+      });
+
+      it("should not have moved the caret to the beginning of the text field", function() {
+        expect(placekeeper.utils.moveCaret).not.toHaveBeenCalled();
+      });
+
+    });
+
   });
 
   describe("when there is a textarea with placeholder and existing value on the page", function() {

--- a/test/unit/focus-blur.spec.js
+++ b/test/unit/focus-blur.spec.js
@@ -72,6 +72,7 @@ describe("focusing and blurring an element with placeholder", function() {
     describe("and when element is focused", function() {
 
       beforeEach(function() {
+        spyOn(placekeeper.utils, "moveCaret");
         spyOn(placekeeper.polyfill, "hidePlaceholder").and.callThrough();
         helpers.focus(element);
       });
@@ -99,6 +100,10 @@ describe("focusing and blurring an element with placeholder", function() {
 
       it("should have restored maxlength attribute", function() {
         expect(parseInt(element.getAttribute("maxLength"), 10)).toEqual(12);
+      });
+
+      it("should have moved the caret to the beginning of the text field", function() {
+        expect(placekeeper.utils.moveCaret).toHaveBeenCalledWith(element, 0);
       });
 
       describe("and when a value is given to the element", function() {


### PR DESCRIPTION
In old Internet Explorer the caret dissapears when tabbing.
